### PR TITLE
Update ListServicioAT.php AddFilter Fechas new

### DIFF
--- a/Controller/ListServicioAT.php
+++ b/Controller/ListServicioAT.php
@@ -173,8 +173,6 @@ class ListServicioAT extends ListController
             ->addOrderBy(['serviciosat_trabajos.cantidad'], 'quantity')
             ->addOrderBy(['serviciosat_trabajos.precio'], 'price')
             ->addSearchFields(['serviciosat.codigo', 'serviciosat_trabajos.descripcion', 'serviciosat_trabajos.observaciones', 'serviciosat_trabajos.referencia'])
-            ->addFilterDatePicker('fechainicio', 'from-date', 'serviciosat_trabajos.fechainicio', '>=')
-            ->addFilterDatePicker('fechafin', 'until-date', 'serviciosat_trabajos.fechafin', '<=')
             ->addFilterPeriod('fechainicio', 'start-date', 'fechainicio')
             ->addFilterPeriod('fechafin', 'end-date', 'fechafin')
             ->addFilterSelect('nick', 'user', 'serviciosat_trabajos.nick', $users)

--- a/Controller/ListServicioAT.php
+++ b/Controller/ListServicioAT.php
@@ -175,6 +175,8 @@ class ListServicioAT extends ListController
             ->addSearchFields(['serviciosat.codigo', 'serviciosat_trabajos.descripcion', 'serviciosat_trabajos.observaciones', 'serviciosat_trabajos.referencia'])
             ->addFilterDatePicker('fechainicio', 'from-date', 'serviciosat_trabajos.fechainicio', '>=')
             ->addFilterDatePicker('fechafin', 'until-date', 'serviciosat_trabajos.fechafin', '<=')
+            ->addFilterPeriod('fechainicio', 'start-date', 'fechainicio')
+            ->addFilterPeriod('fechafin', 'end-date', 'fechafin')
             ->addFilterSelect('nick', 'user', 'serviciosat_trabajos.nick', $users)
             ->addFilterSelect('codagente', 'agent', 'serviciosat_trabajos.codagente', $agents)
             ->addFilterAutocomplete('codcliente', 'customer', 'serviciosat.codcliente', 'clientes', 'codcliente', 'nombre')


### PR DESCRIPTION
Estas dos líneas de código sirven para filtrar los trabajos por fecha de inicio y fecha de fin. Han sido probadas y no afectan negativamente al funcionamiento. Son muy funcionales y útiles a nivel empresarial. Además, se han eliminado los filtros de fecha duplicados