### PR TITLE
Garantizar atomicidad entre cambio de estado y registro en historial

### DIFF
--- a/Model/ServicioAT.php
+++ b/Model/ServicioAT.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of Servicios plugin for FacturaScripts
- * Copyright (C) 2020-2024 Carlos Garcia Gomez <carlos@facturascripts.com>
+ * Copyright (C) 2020-2026 Carlos Garcia Gomez <carlos@facturascripts.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -43,8 +43,8 @@ use FacturaScripts\Dinamic\Model\User;
  */
 class ServicioAT extends ModelClass
 {
-    use ModelTrait;
     use CompanyRelationTrait;
+    use ModelTrait;
 
     /** @var string */
     public $asignado;
@@ -89,22 +89,22 @@ class ServicioAT extends ModelClass
     public $idmaquina4;
 
     /** @var int */
-    public $idtipo;
-
-    /** @var int */
     public $idprioridad;
 
     /** @var int */
     public $idservicio;
 
+    /** @var int */
+    public $idtipo;
+
     /** @var string */
     public $material;
 
-    /** @var string */
-    public $nick;
-
     /** @var double */
     public $neto;
+
+    /** @var string */
+    public $nick;
 
     /** @var string */
     public $observaciones;
@@ -180,7 +180,9 @@ class ServicioAT extends ModelClass
 
         // añadimos el cambio al log
         $messageLog = Tools::trans('deleted-service');
-        $this->log($messageLog);
+        if (false === $this->log($messageLog)) {
+            Tools::log()->error('record-save-error', ['%modelo%' => 'ServicioATLog']);
+        }
 
         return true;
     }
@@ -208,19 +210,19 @@ class ServicioAT extends ModelClass
     }
 
     /**
-     * @return TipoAT[]
-     */
-    public function getAvailableTypes(): array
-    {
-        return TipoAT::all();
-    }
-
-    /**
      * @return EstadoAT[]
      */
     public function getAvailableStatus(): array
     {
         return EstadoAT::all();
+    }
+
+    /**
+     * @return TipoAT[]
+     */
+    public function getAvailableTypes(): array
+    {
+        return TipoAT::all();
     }
 
     public function getCustomer(?string $codcliente = null): Cliente
@@ -251,14 +253,6 @@ class ServicioAT extends ModelClass
         return $result;
     }
 
-    public function getStatus(?int $idestado = null): EstadoAT
-    {
-        $idestado = $idestado ?? $this->idestado;
-        $status = new EstadoAT();
-        $status->load($idestado);
-        return $status;
-    }
-
     public function getPriority(): PrioridadAT
     {
         $priority = new PrioridadAT();
@@ -266,11 +260,12 @@ class ServicioAT extends ModelClass
         return $priority;
     }
 
-    public function getType(): TipoAT
+    public function getStatus(?int $idestado = null): EstadoAT
     {
-        $type = new TipoAT();
-        $type->load($this->idtipo);
-        return $type;
+        $idestado = $idestado ?? $this->idestado;
+        $status = new EstadoAT();
+        $status->load($idestado);
+        return $status;
     }
 
     public function getSubject(): Cliente
@@ -288,6 +283,13 @@ class ServicioAT extends ModelClass
         $where = [Where::eq('idservicio', $this->idservicio)];
         $order = ['fechainicio' => 'ASC', 'horainicio' => 'ASC'];
         return DinTrabajoAT::all($where, $order);
+    }
+
+    public function getType(): TipoAT
+    {
+        $type = new TipoAT();
+        $type->load($this->idtipo);
+        return $type;
     }
 
     public function getUser(?string $nick = null): User
@@ -393,6 +395,78 @@ class ServicioAT extends ModelClass
         return $type === 'new' ? 'NewServicioAT' : parent::url($type, $list);
     }
 
+    protected function notifyAgent(string $notification): void
+    {
+        $agent = new Agente();
+        if (false === $agent->load($this->codagente) || empty($agent->email)) {
+            return;
+        }
+
+        MailNotifier::send($notification, $agent->email, $agent->nombre, [
+            'number' => $this->idservicio,
+            'code' => $this->codigo,
+            'date' => $this->fecha,
+            'customer' => $this->getSubject()->nombre,
+            'author' => $this->nick,
+            'status' => $this->getStatus()->nombre,
+            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
+        ]);
+    }
+
+    protected function notifyAssignedUser(string $notification): void
+    {
+        $assigned = new User();
+        if (false === $assigned->load($this->asignado)) {
+            return;
+        }
+
+        MailNotifier::send($notification, $assigned->email, $assigned->nick, [
+            'number' => $this->idservicio,
+            'code' => $this->codigo,
+            'date' => $this->fecha,
+            'customer' => $this->getSubject()->nombre,
+            'author' => $this->nick,
+            'status' => $this->getStatus()->nombre,
+            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
+        ]);
+    }
+
+    protected function notifyCustomer(string $notification): void
+    {
+        $customer = $this->getSubject();
+        if (empty($customer) || empty($customer->email)) {
+            return;
+        }
+
+        MailNotifier::send($notification, $customer->email, $customer->nombre, [
+            'number' => $this->idservicio,
+            'code' => $this->codigo,
+            'date' => $this->fecha,
+            'customer' => $customer->nombre,
+            'author' => $this->nick,
+            'status' => $this->getStatus()->nombre,
+            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
+        ]);
+    }
+
+    protected function notifyUser(string $notification): void
+    {
+        $user = new User();
+        if (false === $user->load($this->nick)) {
+            return;
+        }
+
+        MailNotifier::send($notification, $user->email, $user->nick, [
+            'number' => $this->idservicio,
+            'code' => $this->codigo,
+            'date' => $this->fecha,
+            'customer' => $this->getSubject()->nombre,
+            'author' => $this->nick,
+            'status' => $this->getStatus()->nombre,
+            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
+        ]);
+    }
+
     protected function onChange(string $field): bool
     {
         if ($field == 'idestado') {
@@ -411,7 +485,9 @@ class ServicioAT extends ModelClass
                 '%oldStatus%' => $this->getStatus($this->getOriginal('idestado'))->nombre,
                 '%newStatus%' => $newStatus->nombre
             ]);
-            $this->log($messageLog);
+            if (false === $this->log($messageLog)) {
+                return false;
+            }
         }
 
         return parent::onChange($field);
@@ -430,8 +506,13 @@ class ServicioAT extends ModelClass
             $this->notifyCustomer('new-service-customer');
         }
 
-        $message = Tools::trans('new-service-created', ['%number%' => $this->id()]);
-        $this->log($message);
+        $message = Tools::trans('new-service-created', [
+            '%number%' => $this->id(),
+            '%status%' => $this->getStatus()->nombre
+        ]);
+        if (false === $this->log($message)) {
+            Tools::log()->error('record-save-error', ['%modelo%' => 'ServicioATLog']);
+        }
 
         parent::onInsert();
     }
@@ -559,77 +640,5 @@ class ServicioAT extends ModelClass
         if ($this->nick) {
             $this->notifyUser('new-service-user');
         }
-    }
-
-    protected function notifyAgent(string $notification): void
-    {
-        $agent = new Agente();
-        if (false === $agent->load($this->codagente) || empty($agent->email)) {
-            return;
-        }
-
-        MailNotifier::send($notification, $agent->email, $agent->nombre, [
-            'number' => $this->idservicio,
-            'code' => $this->codigo,
-            'date' => $this->fecha,
-            'customer' => $this->getSubject()->nombre,
-            'author' => $this->nick,
-            'status' => $this->getStatus()->nombre,
-            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
-        ]);
-    }
-
-    protected function notifyAssignedUser(string $notification): void
-    {
-        $assigned = new User();
-        if (false === $assigned->load($this->asignado)) {
-            return;
-        }
-
-        MailNotifier::send($notification, $assigned->email, $assigned->nick, [
-            'number' => $this->idservicio,
-            'code' => $this->codigo,
-            'date' => $this->fecha,
-            'customer' => $this->getSubject()->nombre,
-            'author' => $this->nick,
-            'status' => $this->getStatus()->nombre,
-            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
-        ]);
-    }
-
-    protected function notifyCustomer(string $notification): void
-    {
-        $customer = $this->getSubject();
-        if (empty($customer) || empty($customer->email)) {
-            return;
-        }
-
-        MailNotifier::send($notification, $customer->email, $customer->nombre, [
-            'number' => $this->idservicio,
-            'code' => $this->codigo,
-            'date' => $this->fecha,
-            'customer' => $customer->nombre,
-            'author' => $this->nick,
-            'status' => $this->getStatus()->nombre,
-            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
-        ]);
-    }
-
-    protected function notifyUser(string $notification): void
-    {
-        $user = new User();
-        if (false === $user->load($this->nick)) {
-            return;
-        }
-
-        MailNotifier::send($notification, $user->email, $user->nick, [
-            'number' => $this->idservicio,
-            'code' => $this->codigo,
-            'date' => $this->fecha,
-            'customer' => $this->getSubject()->nombre,
-            'author' => $this->nick,
-            'status' => $this->getStatus()->nombre,
-            'url' => Tools::siteUrl() . '/EditServicioAT?code=' . $this->idservicio
-        ]);
     }
 }

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -27,7 +27,7 @@
     "new-service-agent-body": "Hola {name}, {author} te ha asignado el servicio {number} para el cliente {customer}. Puedes ver más detalles desde aquí: {url}",
     "new-service-assignee": "Servicio {number} asignado",
     "new-service-assignee-body": "Hola {name}, {author} te ha asignado el servicio {number} para el cliente {customer}. Puedes ver más detalles desde aquí: {url}",
-    "new-service-created": "Servicio creado",
+    "new-service-created": "Servicio creado con el estado %status%",
     "new-service-customer": "Servicio {number} registrado",
     "new-service-customer-body": "Hola {name}, hemos registrado el servicio {number} para atenderte.",
     "new-service-p": "Para crear un servicio primero debes seleccionar o crear un cliente y después una máquina (opcional)",


### PR DESCRIPTION
## Descripción

Se han detectado casos en los que un cambio de estado de un `ServicioAT` se guardaba en la base de datos sin dejar ningún registro en el historial (`serviciosat_logs`). El mecanismo de log estaba bien diseñado, pero la implementación tenía un fallo silencioso.

Adicionalmente, se mejora el mensaje de creación de servicio para incluir el estado inicial, de modo que quede constancia del estado predeterminado con el que se creó.

## Tarea relacionada

[Tarea #4715](https://facturascripts.com/roadmap/4715)

## El problema

En `ServicioAT::onChange()`, el método `log()` era llamado pero su valor de retorno no se comprobaba:

```php
// Antes — retorno ignorado
$this->log($messageLog);
```

Si la escritura en `serviciosat_logs` fallaba por cualquier motivo (error temporal de BD, fallo de codificación JSON, etc.), `onChange()` devolvía `true` igualmente y el `save()` continuaba. El resultado: **el estado cambiaba en la BD pero no quedaba ninguna entrada en el historial**.

El mismo patrón de retorno ignorado también estaba presente en `delete()` y `onInsert()`.

## Solución

### `onChange('idestado')` — operación atómica (cambio crítico)

```php
// Después — si el log falla, se aborta el cambio de estado
if (false === $this->log($messageLog)) {
    return false;
}
```

Si `log()` devuelve `false`, `onChange()` devuelve `false`, lo que provoca que `save()` aborte toda la operación. Ahora **o se graban tanto el cambio de estado como el log, o no se graba ninguno**.

### `delete()` y `onInsert()` — aviso de fallo

En estos dos métodos, la operación principal ya se ha ejecutado antes de llamar a `log()`, por lo que no se puede revertir. En su lugar se registra un error visible en el log del sistema:

```php
if (false === $this->log($messageLog)) {
    Tools::log()->error('record-save-error', ['%modelo%' => 'ServicioATLog']);
}
```

### Log de creación con estado inicial

El mensaje de creación de un servicio ahora incluye el estado con el que se creó:

- **Antes:** `"Servicio creado"`
- **Después:** `"Servicio creado con el estado En proceso"`

Esto es especialmente útil porque el estado predeterminado puede cambiar con el tiempo, y antes no quedaba constancia del estado inicial.

## Cambios realizados

- `Model/ServicioAT.php` — `onChange()`: devolver `false` si `log()` falla (garantía de atomicidad)
- `Model/ServicioAT.php` — `delete()`: registrar error si `log()` falla tras el borrado
- `Model/ServicioAT.php` — `onInsert()`: registrar error si `log()` falla tras la inserción; incluir estado en el mensaje
- `Translation/es_ES.json`: actualizar clave `new-service-created` con el parámetro `%status%`

## Cómo probar

1. Crear un nuevo servicio y comprobar que el historial muestra el mensaje con el estado inicial (ej. _"Servicio creado con el estado En proceso"_).
2. Cambiar el estado de un servicio existente y verificar que aparece una entrada en el historial con el estado anterior y el nuevo.
3. Para verificar la atomicidad: renombrar temporalmente la tabla `serviciosat_logs` y comprobar que al intentar cambiar el estado, la operación es rechazada completamente (ni el estado ni el log se graban) en lugar de guardarse el estado sin log.

🤖 Generado con [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>