### PR TITLE
fix(AdminServicios): respetar el orden seleccionado por el usuario en Categorías

### DIFF
--- a/Controller/AdminServicios.php
+++ b/Controller/AdminServicios.php
@@ -106,7 +106,7 @@ class AdminServicios extends PanelController
                 break;
 
             case self::VIEW_LIST_CATEGORIES:
-                $view->loadData('', [], ['name' => 'ASC']);
+                $view->loadData();
                 break;
 
             case self::VIEW_LIST_PRIORITIES:


### PR DESCRIPTION
El select de ordenación del listado de Categorías (Administrador > Servicios > Categorías) no funcionaba: al cambiar la opción, el listado no se reordenaba.

La causa era que `AdminServicios::loadData()` pasaba siempre un orden fijo (`['name' => 'ASC']`) a `$view->loadData()`. Como `ListView::loadData()` del core solo respeta el orden ya calculado a partir de la selección del usuario cuando el `$order` recibido está vacío, ese valor fijo sobrescribía en cada petición la opción elegida en el desplegable.

Se corrige eliminando ese orden fijo, dejando que prevalezca el orden por defecto definido en `addOrderBy()` y, tras eso, la selección del usuario.

Tarea: https://facturascripts.com/roadmap/4929