### PR TITLE
Añadir gestión de máquinas activas e inactivas

### DIFF
--- a/Controller/EditServicioAT.php
+++ b/Controller/EditServicioAT.php
@@ -60,6 +60,25 @@ class EditServicioAT extends EditController
         return $data;
     }
 
+    protected function autocompleteAction(): array
+    {
+        $data = $this->requestGet(['source', 'fieldcode', 'fieldtitle', 'term']);
+        if ($data['source'] !== 'serviciosat_maquinas') {
+            return parent::autocompleteAction();
+        }
+
+        $where = [Where::eq('activo', true)];
+
+        $result = [];
+        foreach ($this->codeModel->search($data['source'], $data['fieldcode'], $data['fieldtitle'], $data['term'], $where) as $value) {
+            $result[] = ['key' => Tools::fixHtml($value->code), 'value' => Tools::fixHtml($value->description)];
+        }
+
+        return empty($result)
+            ? [['key' => null, 'value' => Tools::trans('no-data')]]
+            : $result;
+    }
+
     /**
      * Calculate the number of hours worked.
      *

--- a/Controller/ListServicioAT.php
+++ b/Controller/ListServicioAT.php
@@ -58,6 +58,12 @@ class ListServicioAT extends ListController
         $manufacturers = $this->codeModel->all('fabricantes', 'codfabricante', 'nombre');
         $agents = $this->codeModel->all('agentes', 'codagente', 'nombre');
 
+        $valuesWhere = [
+            ['label' => Tools::trans('all'), 'where' => []],
+            ['label' => Tools::trans('only-active'), 'where' => [Where::eq('activo', true)]],
+            ['label' => Tools::trans('inactive'), 'where' => [Where::eq('activo', false)]],
+        ];
+
         $this->addView($viewName, 'MaquinaAT', 'machines', 'fa-solid fa-laptop-medical')
             ->addOrderBy(['idmaquina'], 'code', 2)
             ->addOrderBy(['fecha'], 'date')
@@ -65,6 +71,7 @@ class ListServicioAT extends ListController
             ->addOrderBy(['referencia'], 'reference')
             ->addSearchFields(['descripcion', 'idmaquina', 'nombre', 'numserie', 'referencia'])
             ->addFilterPeriod('fecha', 'date', 'fecha')
+            ->addFilterSelectWhere('activo', $valuesWhere)
             ->addFilterSelect('codfabricante', 'manufacturer', 'codfabricante', $manufacturers)
             ->addFilterAutocomplete('codcliente', 'customer', 'codcliente', 'clientes', 'codcliente', 'nombre')
             ->addFilterSelect('codagente', 'agent', 'codagente', $agents);

--- a/Controller/NewServicioAT.php
+++ b/Controller/NewServicioAT.php
@@ -203,6 +203,11 @@ class NewServicioAT extends Controller
             return false;
         }
 
+        // no permitimos crear servicios sobre máquinas desactivadas
+        if (false === (bool)$machine->activo) {
+            return false;
+        }
+
         // si no hay cliente, usamos el cliente de la máquina
         if (empty($this->codcliente)) {
             $this->codcliente = $machine->codcliente;
@@ -260,7 +265,7 @@ class NewServicioAT extends Controller
             ];
         }
 
-        $whereCustomer = [Where::eq('codcliente', $customer->codcliente)];
+        $whereCustomer = [Where::eq('codcliente', $customer->codcliente), Where::eq('activo', true)];
         $customerMachines = MaquinaAT::all($whereCustomer, $orderBy);
         foreach ($customerMachines as $machine) {
             $html .= '<tr class="clickableRow" data-idmaquina="' . $machine->idmaquina . '">'
@@ -270,7 +275,7 @@ class NewServicioAT extends Controller
                 . '</tr>';
         }
 
-        $whereAnonymous = [Where::isNull('codcliente')];
+        $whereAnonymous = [Where::isNull('codcliente'), Where::eq('activo', true)];
         $anonymousMachines = MaquinaAT::all($whereAnonymous, $orderBy);
         if (false === empty($anonymousMachines)) {
             $html .= '<tr class="table-info"><td class="text-center" colspan="3">'
@@ -278,7 +283,7 @@ class NewServicioAT extends Controller
                 . '</td></tr>';
         }
 
-        $whereAnonymous = [Where::isNull('codcliente')];
+        $whereAnonymous = [Where::isNull('codcliente'), Where::eq('activo', true)];
         foreach (MaquinaAT::all($whereAnonymous, $orderBy) as $machine) {
             $html .= '<tr class="clickableRow" data-idmaquina="' . $machine->idmaquina . '">'
                 . '<td>' . $machine->nombre . '</td>'
@@ -349,6 +354,7 @@ class NewServicioAT extends Controller
         }
 
         $machine = new MaquinaAT();
+        $machine->activo = (bool)$this->request->get('active', true);
         $machine->codcliente = $this->request->get('codcliente');
         $machine->nombre = $this->request->get('name');
         $machine->numserie = $this->request->get('serial_number');
@@ -366,6 +372,12 @@ class NewServicioAT extends Controller
 
         if (false === $machine->save()) {
             Tools::log()->error('save-error');
+            return ['saveNewMachine' => false];
+        }
+
+        // una máquina desactivada no puede asignarse al servicio que se está creando
+        if (false === $machine->activo) {
+            Tools::log()->warning('inactive-machine-cant-be-selected');
             return ['saveNewMachine' => false];
         }
 

--- a/Model/MaquinaAT.php
+++ b/Model/MaquinaAT.php
@@ -34,6 +34,9 @@ class MaquinaAT extends ModelClass
 {
     use ModelTrait;
 
+    /** @var bool Indica si la máquina está activa y puede seleccionarse en nuevos servicios. */
+    public $activo;
+
     /** @var string Código del agente relacionado con la máquina. */
     public $codagente;
 
@@ -64,6 +67,7 @@ class MaquinaAT extends ModelClass
     public function clear(): void
     {
         parent::clear();
+        $this->activo = true;
         $this->fecha = Tools::date();
     }
 

--- a/Table/serviciosat_maquinas.xml
+++ b/Table/serviciosat_maquinas.xml
@@ -6,6 +6,11 @@
 -->
 <table>
     <column>
+        <name>activo</name>
+        <type>boolean</type>
+        <default>true</default>
+    </column>
+    <column>
         <name>codagente</name>
         <type>character varying(10)</type>
     </column>

--- a/Test/main/MaquinaAtTest.php
+++ b/Test/main/MaquinaAtTest.php
@@ -50,6 +50,28 @@ final class MaquinaAtTest extends TestCase
         $this->assertTrue($customer->delete());
     }
 
+    public function testActive(): void
+    {
+        // una máquina nueva está activa por defecto
+        $machine = new MaquinaAT();
+        $this->assertTrue($machine->activo);
+
+        $machine->nombre = 'Test active machine';
+        $this->assertTrue($machine->save());
+
+        // la desactivamos
+        $machine->activo = false;
+        $this->assertTrue($machine->save());
+
+        // recargamos y comprobamos que sigue desactivada
+        $reloaded = new MaquinaAT();
+        $this->assertTrue($reloaded->load($machine->idmaquina));
+        $this->assertFalse((bool)$reloaded->activo);
+
+        // eliminamos
+        $this->assertTrue($machine->delete());
+    }
+
     public function testEscapeHtml(): void
     {
         $html = '<br/>';

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -18,6 +18,7 @@
     "customer-machines": "Máquinas del cliente",
     "deleted-service": "Servicio eliminado",
     "generated-services": "%quantity% servicios generados.",
+    "inactive-machine-cant-be-selected": "La máquina se ha guardado como inactiva, por lo que no puede asignarse al servicio.",
     "make-delivery-note": "Hacer albarán",
     "make-estimation": "Hacer presupuesto",
     "material": "Material",

--- a/View/NewServicioAT.html.twig
+++ b/View/NewServicioAT.html.twig
@@ -314,6 +314,10 @@
                             {{ trans('description') }}
                             <textarea name="description" class="form-control" maxlength="100"></textarea>
                         </div>
+                        <div class="form-check mb-3">
+                            <input type="checkbox" name="active" id="newMachineActive" class="form-check-input" checked/>
+                            <label class="form-check-label" for="newMachineActive">{{ trans('active') }}</label>
+                        </div>
                         {% for item in getIncludeViews('NewServicioAT', 'newMachineModal') %}
                             {% include item['path'] %}
                         {% endfor %}
@@ -429,9 +433,11 @@
             let formData = new FormData();
             formData.append('codcliente', codcliente);
 
-            $('#newMachineModal input').each(function () {
+            $('#newMachineModal input:not([type=checkbox])').each(function () {
                 formData.append($(this).attr('name'), $(this).val());
             });
+
+            formData.append('active', $('#newMachineActive').is(':checked') ? '1' : '0');
 
             $('#newMachineModal select').each(function () {
                 formData.append($(this).attr('name'), $(this).find('option:selected').val());

--- a/XMLView/EditMaquinaAT.xml
+++ b/XMLView/EditMaquinaAT.xml
@@ -54,6 +54,9 @@
                     <values source="agentes" fieldcode="codagente" fieldtitle="nombre" />
                 </widget>
             </column>
+            <column name="active" display="center" order="190">
+                <widget type="checkbox" fieldname="activo" />
+            </column>
         </group>
     </columns>
 </view>

--- a/XMLView/ListMaquinaAT.xml
+++ b/XMLView/ListMaquinaAT.xml
@@ -48,5 +48,8 @@
         <column name="date" display="right" order="170">
             <widget type="date" fieldname="fecha" />
         </column>
+        <column name="active" display="center" order="180">
+            <widget type="checkbox" fieldname="activo" />
+        </column>
     </columns>
 </view>


### PR DESCRIPTION
-Se añade check "Activo", si esta marcado la maquina es elegible, si no está, no aparece ni al crear nuevo servicio, ni en el modal para elegirla dentro de un servicio creado. 
-El check se marca por defecto al crearla.
-Si la máquina esta usandose en un servicio y se desmarca activo, sigue vinculada a ese servicio.

<img width="1903" height="406" alt="Captura de pantalla 2026-08-14 124635" src="https://github.com/user-attachments/assets/a415ae7c-e5bd-4a58-a005-ffa73ebc6fa9" />

- Se añade una nueva columna 'active' en EditMaquinaAT.xml y ListMaquinaAT.xml para gestionar el estado de las máquinas.
- Se implementa la lógica para permitir la creación de servicios solo sobre máquinas activas en NewServicioAT.php.
- Se actualiza el modelo MaquinaAT.php para incluir el atributo 'activo'.
- Se añaden mensajes de error en español para máquinas inactivas en NewServicioAT.php.
- Se implementa un test para verificar el comportamiento de las máquinas activas en MaquinaAtTest.php.